### PR TITLE
Adding SEPPmail AG as a Silver sponsor for 2020. No update of the tot…

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -120,7 +120,8 @@ $5000 or more, and display your logo for donations of $10,000 or more.
   </UL>
 <LI> Silver: $10,000 to $25,000
   <UL>
-    <LI>John Carmack
+      <LI>John Carmack
+      <LI>SEPPmail AG
   </UL>
 <LI> Bronze: $5,000 to $10,000
   <UL>


### PR DESCRIPTION
…al is needed because the contribution was already reflected in the previous update